### PR TITLE
Fix: select only one file or folder at a time

### DIFF
--- a/app/components/FileItem.tsx
+++ b/app/components/FileItem.tsx
@@ -119,7 +119,7 @@ export default function FileItem({
   if (view === "grid") {
     return (
       <section
-        className={`group relative flex cursor-pointer flex-col items-center justify-center rounded-lg border-2 p-2 transition-colors sm:p-4 ${isSelected
+        className={`group relative flex cursor-pointer select-none flex-col items-center justify-center rounded-lg border-2 p-2 transition-colors sm:p-4 ${isSelected
             ? "border-[#7B42F6] bg-[#F9F6FF]"
             : "border-transparent bg-white hover:border-gray-300 hover:bg-gray-50"
           }`}
@@ -163,7 +163,7 @@ export default function FileItem({
   // List view
   return (
     <section
-      className={`group flex cursor-pointer items-center gap-2 border-b border-gray-100 px-2 py-2 transition-colors sm:gap-4 sm:px-4 sm:py-3 ${isSelected ? "bg-[#F9F6FF]" : "bg-white hover:bg-gray-50"
+      className={`group flex cursor-pointer select-none items-center gap-2 border-b border-gray-100 px-2 py-2 transition-colors sm:gap-4 sm:px-4 sm:py-3 ${isSelected ? "bg-[#F9F6FF]" : "bg-white hover:bg-gray-50"
         }`}
       style={{ touchAction: 'manipulation' }}
       onMouseEnter={() => setIsHovered(true)}

--- a/app/components/FileManager.tsx
+++ b/app/components/FileManager.tsx
@@ -752,12 +752,7 @@ export default function FileManager() {
   };
 
   const handleFileSelect = (file: FileItemData) => {
-    setSelectedFileIds((prev) => {
-      if (prev.includes(file.id)) {
-        return prev.filter((id) => id !== file.id);
-      }
-      return [...prev, file.id];
-    });
+    setSelectedFileIds([file.id])
   };
 
   const handleBreadcrumbNavigate = (path: string) => {


### PR DESCRIPTION
Clicking a file or folder now highlights only that item. Previously each click added to the selection, so multiple items stayed highlighted.
Fixes #52 
